### PR TITLE
fix:  playlist title clear

### DIFF
--- a/sVanilla/src/ClientUi/VideoList/VideoWidget.cpp
+++ b/sVanilla/src/ClientUi/VideoList/VideoWidget.cpp
@@ -360,6 +360,7 @@ void VideoWidget::prepareVideoItem(const biliapi::VideoViewOrigin& videoView)
     // 2. add video item
     const QString tempPath = QApplication::applicationDirPath();  // It is now in the temporary area
     const auto views = ConvertVideoView(videoView.data);
+    ui->labelPlayListTitle->clear();
     if (const auto playlistTitle = views.front()->PlayListTitle; !playlistTitle.empty())
     {
         const auto title = QString::fromStdString(playlistTitle) + "(" + QString::number(views.size()) + ")";


### PR DESCRIPTION
After re-searching the video, the playlist title was not cleared