### PR TITLE
fix(ci): stabilize release workflow warnings

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -39,13 +39,15 @@ jobs:
 
     steps:
       - name: Get clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Get cmake 
         uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.31.8
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -54,7 +56,7 @@ jobs:
           vcpkgDirectory: '${{ github.workspace }}/ThirdParty/vcpkg'
 
       - name: Install Qt Official Build
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.qt_version }}
           target: desktop
@@ -124,12 +126,17 @@ jobs:
           light.exe -nologo -out ${{ matrix.asset_path }}/${{ env.product_name }}_${{ env.ref_id}}_win64_installer.msi installer/${{ env.product_name }}.wixobj installer/ui.wixobj  -ext WixUIExtension
           Remove-Item -Path "${{ matrix.asset_path }}/${{ env.product_name }}_${{ env.ref_id}}_win64_installer.wixpdb" -Force
 
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
       - name: create .EXE Installer
         id: create_exe_installer
-        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
-        with:
-          path: scripts/inno_setup/installer.iss
-          options: /DRootPath=${{ github.workspace }}/${{ matrix.install_path }}/bin /DCurrenData=${{ env.ref_id}} /DMyAppVersion=${{ env.VERSION}} /O${{ github.workspace }}/${{ matrix.asset_path }}
+        run: >
+          iscc scripts/inno_setup/installer.iss
+          /DRootPath=${{ github.workspace }}/${{ matrix.install_path }}/bin
+          /DCurrenData=${{ env.ref_id}}
+          /DMyAppVersion=${{ env.VERSION}}
+          /O${{ github.workspace }}/${{ matrix.asset_path }}
       
       - name: Archive build logs on failure
         if: ${{ failure() && (steps.create_msi.outcome == 'failure' || steps.create_exe_installer.outcome == 'failure') }}
@@ -140,7 +147,7 @@ jobs:
 
       - name: Upload build logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows_release_logs
           path: |
@@ -158,7 +165,7 @@ jobs:
           }
 
       - name: Update GitHub Release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows
           path: |
@@ -168,6 +175,7 @@ jobs:
             ${{ matrix.asset_path }}/*.exe
 
       - name: Upload Release Assets
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           $files = Get-ChildItem -Path ${{ matrix.asset_path }}/*;
           foreach ($file in $files) {
@@ -192,12 +200,14 @@ jobs:
         cpp_compiler: [g++]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
 
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.31.8
 
       - name: Install Dependencies
         run: |
@@ -211,7 +221,7 @@ jobs:
           vcpkgDirectory: '${{ github.workspace }}/ThirdParty/vcpkg'
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.qt_version }}
           target: desktop
@@ -296,7 +306,7 @@ jobs:
 
       - name: Upload build logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux_release_logs
           path: |
@@ -312,7 +322,7 @@ jobs:
           done
 
       - name: Update GitHub Release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux
           path: |
@@ -321,6 +331,7 @@ jobs:
             ${{ matrix.asset_path }}/*.tar.gz
 
       - name: Upload Release Assets
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           files=$(find ${{ matrix.asset_path }} -type f);
           for file in $files; do
@@ -344,12 +355,14 @@ jobs:
           cpp_compiler: [clang++]
 
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
           with:
             submodules: recursive
             fetch-depth: 0
 
         - uses: lukka/get-cmake@latest
+          with:
+            cmakeVersion: 3.31.8
 
         - name: Setup Python venv (global)
           run: |
@@ -429,7 +442,7 @@ jobs:
 
         - name: Upload build logs artifact
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v6
           with:
             name: macos_release_logs
             path: |
@@ -447,7 +460,7 @@ jobs:
             done
 
         - name: Update GitHub Release
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v6
           with:
             name: macos
             path: |
@@ -456,6 +469,7 @@ jobs:
               ${{ matrix.asset_path }}/*.tar.gz
 
         - name: Upload Release Assets
+          if: ${{ startsWith(github.ref, 'refs/tags/') }}
           run: |
             files=$(find ${{ matrix.asset_path }} -type f);
             for file in $files; do
@@ -479,12 +493,14 @@ jobs:
             cpp_compiler: [clang++]
 
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v5
             with:
               submodules: recursive
               fetch-depth: 0
 
           - uses: lukka/get-cmake@latest
+            with:
+              cmakeVersion: 3.31.8
 
           - name: Set up virtualenv and inject PATH
             run: |
@@ -563,7 +579,7 @@ jobs:
 
           - name: Upload build logs artifact
             if: failure()
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@v6
             with:
               name: macos_release_logs
               path: |
@@ -581,7 +597,7 @@ jobs:
               done
 
           - name: Update GitHub Release
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@v6
             with:
               name: macos_arm
               path: |
@@ -590,6 +606,7 @@ jobs:
                 ${{ matrix.asset_path }}/*.tar.gz
 
           - name: Upload Release Assets
+            if: ${{ startsWith(github.ref, 'refs/tags/') }}
             run: |
               files=$(find ${{ matrix.asset_path }} -type f);
               for file in $files; do

--- a/cmake/terminate_process.cmake
+++ b/cmake/terminate_process.cmake
@@ -8,18 +8,21 @@ function(kill_process_by_path executable_path)
 
     get_filename_component(process_name "${executable_path}" NAME)
 
-    if(WIN32)
+    if(CMAKE_HOST_WIN32)
         string(REPLACE "/" "\\" executable_path "${executable_path}.exe")
 
         execute_process(
-            COMMAND powershell -Command "
-                Get-Process -Name '${process_name}' -ErrorAction SilentlyContinue |
-                Stop-Process -Force;
+            COMMAND powershell -NoProfile -Command "
+                $procs = Get-Process -Name '${process_name}' -ErrorAction SilentlyContinue;
+                if ($procs) {
+                    $procs | Stop-Process -Force -ErrorAction Stop;
+                }
+                exit 0;
             "
             RESULT_VARIABLE result
             ERROR_QUIET
         )
-    elseif(APPLE OR UNIX)
+    elseif(CMAKE_HOST_APPLE OR CMAKE_HOST_UNIX)
         if(NOT EXISTS "${executable_path}")
             message("Executable path does not exist: ${executable_path}, skipping process termination.")
             return()


### PR DESCRIPTION
### Motivation
- Follow-up Actions run `29730545620` still showed CI warnings and failures due to a remaining Node.js 20 action (`Minionguyjpro/Inno-Setup-Action`) and `gh release upload` attempts on non-tag `workflow_dispatch` runs. 
- `lukka/get-cmake@latest` can pull CMake 4.x and trigger new script-mode annotations, so the workflow should request a stable CMake version to avoid noise. 
- Keep the earlier CMake script-mode host-detection fixes for process termination while not modifying any `.md` files per request. 

### Description
- Updated `.github/workflows/ci-release.yml` to remove the Node.js 20 action by replacing `Minionguyjpro/Inno-Setup-Action@v1.2.2` with a Chocolatey `choco install innosetup` step and a direct `iscc` invocation for the Windows `.exe` installer. 
- Pinned the CMake version requested from `lukka/get-cmake@latest` by adding `with: cmakeVersion: 3.31.8` to all release jobs to avoid CMake 4.x-induced script-mode warnings. 
- Bumped `actions/checkout` to `@v5`, `jurplel/install-qt-action` to `@v4`, and `actions/upload-artifact` to `@v6` in the release workflow, and gated `gh release upload` steps with `if: startsWith(github.ref, 'refs/tags/')` so uploads only run for tag releases. 
- Kept and clarified `cmake/terminate_process.cmake` changes: use `CMAKE_HOST_WIN32`/`CMAKE_HOST_APPLE`/`CMAKE_HOST_UNIX`, run PowerShell with `-NoProfile` and safe stop logic, and make Unix `pkill` invocation tolerant when the executable path is missing. 
- Modified files: `.github/workflows/ci-release.yml` and `cmake/terminate_process.cmake` (no `.md` changes). 

### Testing
- Ran workflow assertions with a Python check that validated the updated `lukka/get-cmake` occurrences, `cmakeVersion` count, and tag gating, and the script completed successfully. 
- Executed `cmake -DEXECUTABLE_PATH=/tmp/svanilla-nonexistent -P cmake/terminate_process.cmake` to verify script-mode behavior, which returned the expected skip message. 
- Loaded the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-release.yml')"` and ran `git diff --check`, both of which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5de2ea028083299347e8c95debbded)